### PR TITLE
Callback url option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Twitter supports a [few options](https://dev.twitter.com/docs/api/1/get/oauth/au
 
 The options are:
 
+* **callback_url** - This options gives a possibility to override default callback url.
+
 * **force_login** - This option sends the user to a sign-in screen to enter their Twitter credentials, even if they are already signed in. This is handy when your application supports multiple Twitter accounts and you want to ensure the correct user is signed in. *Example:* `http://yoursite.com/auth/twitter?force_login=true`
 
 * **screen_name** - This option implies **force_login**, except the screen name field is pre-filled with a particular value. *Example:* `http://yoursite.com/auth/twitter?screen_name=jim`

--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -61,26 +61,8 @@ module OmniAuth
         old_request_phase
       end
 
-      alias :old_callback_url :callback_url
-
       def callback_url
-        if request.params['callback_url']
-          request.params['callback_url']
-        elsif options[:callback_url]
-          options[:callback_url]
-        else
-          old_callback_url
-        end
-      end
-
-      def callback_path
-        params = session['omniauth.params']
-
-        if (params && params['callback_url']) || options[:callback_url]
-          URI(callback_url).path
-        else
-          super
-        end
+        options[:callback_url] || (full_host + script_name + callback_path)
       end
 
       private

--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -62,7 +62,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:callback_url] || (full_host + script_name + callback_path)
+        options[:callback_url] || super
       end
 
       private

--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -66,6 +66,8 @@ module OmniAuth
       def callback_url
         if request.params['callback_url']
           request.params['callback_url']
+        elsif options[:callback_url]
+          options[:callback_url]
         else
           old_callback_url
         end
@@ -74,10 +76,10 @@ module OmniAuth
       def callback_path
         params = session['omniauth.params']
 
-        if params.nil? || params['callback_url'].nil?
-          super
+        if (params && params['callback_url']) || options[:callback_url]
+          URI(callback_url).path
         else
-          URI(params['callback_url']).path
+          super
         end
       end
 

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -151,6 +151,27 @@ describe OmniAuth::Strategies::Twitter do
       end
     end
 
+    context 'when callback set in options' do
+      before do
+        @options = { :callback_url => 'http://foo.dev/auth/twitter/foobar' }
+        allow(subject).to receive(:request) do
+          double('Request', {:params => {} })
+        end
+        allow(subject).to receive(:session) do
+          double('Session', :[] => {})
+        end
+        allow(subject).to receive(:old_request_phase) { :whatever }
+      end
+
+      it 'should use the callback_url' do
+        expect(subject.callback_url).to eq 'http://foo.dev/auth/twitter/foobar'
+      end
+
+      it 'should return the correct callback_path' do
+        expect(subject.callback_path).to eq '/auth/twitter/foobar'
+      end
+    end
+
     context 'with no callback_url set' do
       before do
         allow(subject).to receive(:request) do

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -130,27 +130,6 @@ describe OmniAuth::Strategies::Twitter do
       end
     end
 
-    context 'with a specified callback_url in the params' do
-      before do
-        params = { 'callback_url' => 'http://foo.dev/auth/twitter/foobar' }
-        allow(subject).to receive(:request) do
-          double('Request', :params => params)
-        end
-        allow(subject).to receive(:session) do
-          double('Session', :[] => { 'callback_url' => params['callback_url'] })
-        end
-        allow(subject).to receive(:old_request_phase) { :whatever }
-      end
-
-      it 'should use the callback_url' do
-        expect(subject.callback_url).to eq 'http://foo.dev/auth/twitter/foobar'
-      end
-
-      it 'should return the correct callback_path' do
-        expect(subject.callback_path).to eq '/auth/twitter/foobar'
-      end
-    end
-
     context 'when callback set in options' do
       before do
         @options = { :callback_url => 'http://foo.dev/auth/twitter/foobar' }
@@ -166,10 +145,6 @@ describe OmniAuth::Strategies::Twitter do
       it 'should use the callback_url' do
         expect(subject.callback_url).to eq 'http://foo.dev/auth/twitter/foobar'
       end
-
-      it 'should return the correct callback_path' do
-        expect(subject.callback_path).to eq '/auth/twitter/foobar'
-      end
     end
 
     context 'with no callback_url set' do
@@ -182,10 +157,6 @@ describe OmniAuth::Strategies::Twitter do
         end
         allow(subject).to receive(:old_request_phase) { :whatever }
         allow(subject).to receive(:old_callback_url).and_return(:old_callback)
-      end
-
-      it 'callback_url should return nil' do
-        expect(subject.callback_url).to eq :old_callback
       end
 
       it 'should return the default callback_path value' do


### PR DESCRIPTION
Added `callback_url` option. Removed support for the same name parameter.